### PR TITLE
Fix method ambiguity error of `shuffle!` with `AbstractArray{Bool}` on Julia 1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,18 @@
 name    = "StableRNGs"
 uuid    = "860ef19b-820b-49d6-a774-d7a799459cd3"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Test   = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Random = "<0.0.1, 1"
+Test = "<0.0.1, 1"
 julia = "1"
+
+[extras]
+Test   = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/StableRNGs.jl
+++ b/src/StableRNGs.jl
@@ -141,7 +141,10 @@ end
 
 # https://github.com/JuliaRandom/StableRNGs.jl/issues/10
 Random.shuffle(r::StableRNG, a::AbstractArray) = Random.shuffle!(r, Base.copymutable(a))
-function Random.shuffle!(r::StableRNG, a::AbstractArray)
+# Fix method ambiguity issue: https://github.com/JuliaRandom/StableRNGs.jl/issues/23
+Random.shuffle!(r::StableRNG, a::AbstractArray) = _shuffle!(r, a)
+Random.shuffle!(r::StableRNG, a::AbstractArray{Bool}) = _shuffle!(r, a)
+function _shuffle!(r::StableRNG, a::AbstractArray)
     require_one_based_indexing(a)
     n = length(a)
     n <= 1 && return a # nextpow below won't work with n == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,4 +139,12 @@ end
     b = collect(a)
     shuffle!(StableRNG(10), b)
     @test b == a_shuffled
+
+    # https://github.com/JuliaRandom/StableRNGs.jl/issues/23
+    c = [false, true, false, true, false]
+    c_shuffled = [false, false, false, true, true]
+    @test shuffle!(StableRNG(123), c) == c_shuffled
+    d = [false true; true false]
+    d_shuffled = [true true; false false]
+    @test shuffle(StableRNG(31), d) == d_shuffled
 end


### PR DESCRIPTION
Fixes #23.