### PR TITLE
fix(compat): Explicit qualification for of `Sampler` type

### DIFF
--- a/src/StableRNGs.jl
+++ b/src/StableRNGs.jl
@@ -135,7 +135,7 @@ end
 
 for T in Base.BitInteger_types
     # eval because of ambiguities with `where T <: BitInteger`
-    @eval Sampler(::Type{LehmerRNG}, r::AbstractUnitRange{$T}, ::Random.Repetition) =
+    @eval Random.Sampler(::Type{LehmerRNG}, r::AbstractUnitRange{$T}, ::Random.Repetition) =
         SamplerRangeFast(r)
 end
 


### PR DESCRIPTION
Inference of the parent module of the overridden type is not supported
any more in julia 1.12 and newer.
